### PR TITLE
Add postSerialize method to model

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -54,6 +54,10 @@ let _serialize = function (model, pojo, options) {
     }
   });
 
+  if (model.postSerialize) {
+    model.postSerialize(pojo, options);
+  }
+
   return pojo;
 };
 


### PR DESCRIPTION
A postDeserialize method exists, but one did not exist for after
serialization.  Used to modify the pojo result after seralization.

In my case, I needed to add a pojo._id for passing back to mongo and
this method allows me to add that after the serialization has been done
  postSerialize(pojo) {
    pojo._id = this.id;
  }